### PR TITLE
*: add global variable for stream table pos

### DIFF
--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -125,7 +125,7 @@ func checkStreamType(args map[string]string) error {
 	}
 
 	tp := strings.ToLower(key)
-	if tp != "kafka" && tp != "pulsar" && tp != "binlog" && tp != "log" {
+	if tp != "kafka" && tp != "pulsar" && tp != "binlog" && tp != "log" && tp != "demo" {
 		return errors.New("Invalid stream table type")
 	}
 

--- a/executor/stream_reader.go
+++ b/executor/stream_reader.go
@@ -68,7 +68,10 @@ func (e *StreamReaderExecutor) Open(ctx context.Context) error {
 	e.setVariableName(strings.ToLower(tp))
 
 	var err error
-	value, _ := e.ctx.GetSessionVars().GlobalVarsAccessor.GetGlobalSysVar(e.variableName)
+	value, err := e.ctx.GetSessionVars().GlobalVarsAccessor.GetGlobalSysVar(e.variableName)
+	if err != nil {
+		return errors.Trace(err)
+	}
 	if value != "" {
 		e.pos, err = strconv.Atoi(value)
 		if err != nil {
@@ -94,8 +97,6 @@ func (e *StreamReaderExecutor) Next(ctx context.Context, chk *chunk.Chunk) error
 	if err != nil {
 		return errors.Trace(err)
 	}
-
-	log.Warnf("[qiuyesuifeng]%v:%v:%v", e.Table, e.cursor, e.pos)
 
 	chk.GrowAndReset(e.maxChunkSize)
 	if e.result == nil {

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -675,7 +675,7 @@ var defaultSysVars = []*SysVar{
 	{ScopeGlobal | ScopeSession, TiDBKafkaStreamTablePos, "0"},
 	{ScopeGlobal | ScopeSession, TiDBPulsarStreamTablePos, "0"},
 	{ScopeGlobal | ScopeSession, TiDBLogStreamTablePos, "0"},
-	{ScopeGlobal | ScopeSession, TiDBDemoStreamTablePos, "0"},
+	{ScopeGlobal | ScopeSession, TiDBStreamTableDemoPos, "0"},
 }
 
 // SynonymsSysVariables is synonyms of system variables.

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -670,6 +670,11 @@ var defaultSysVars = []*SysVar{
 	{ScopeSession, TiDBDDLReorgPriority, "PRIORITY_LOW"},
 	{ScopeSession, TiDBForcePriority, mysql.Priority2Str[DefTiDBForcePriority]},
 	{ScopeSession, TiDBEnableRadixJoin, boolToIntStr(DefTiDBUseRadixJoin)},
+
+	// Stream Table Variable
+	{ScopeGlobal | ScopeSession, TiDBKafkaStreamTablePos, "0"},
+	{ScopeGlobal | ScopeSession, TiDBPulsarStreamTablePos, "0"},
+	{ScopeGlobal | ScopeSession, TiDBLogStreamTablePos, "0"},
 }
 
 // SynonymsSysVariables is synonyms of system variables.

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -675,6 +675,7 @@ var defaultSysVars = []*SysVar{
 	{ScopeGlobal | ScopeSession, TiDBKafkaStreamTablePos, "0"},
 	{ScopeGlobal | ScopeSession, TiDBPulsarStreamTablePos, "0"},
 	{ScopeGlobal | ScopeSession, TiDBLogStreamTablePos, "0"},
+	{ScopeGlobal | ScopeSession, TiDBDemoStreamTablePos, "0"},
 }
 
 // SynonymsSysVariables is synonyms of system variables.

--- a/sessionctx/variable/tidb_vars.go
+++ b/sessionctx/variable/tidb_vars.go
@@ -215,6 +215,16 @@ const (
 	// tidb_constraint_check_in_place indicates to check the constraint when the SQL executing.
 	// It could hurt the performance of bulking insert when it is ON.
 	TiDBConstraintCheckInPlace = "tidb_constraint_check_in_place"
+
+	// Hack for stream table demo
+	// tidb kafka stream table pos
+	TiDBKafkaStreamTablePos = "tidb_kafka_stream_table_pos"
+
+	// tidb pulsar stream table pos
+	TiDBPulsarStreamTablePos = "tidb_pulsar_stream_table_pos"
+
+	// tidb log stream table pos
+	TiDBLogStreamTablePos = "tidb_log_stream_table_pos"
 )
 
 // Default TiDB system variable values.

--- a/sessionctx/variable/tidb_vars.go
+++ b/sessionctx/variable/tidb_vars.go
@@ -226,8 +226,8 @@ const (
 	// tidb log stream table pos
 	TiDBLogStreamTablePos = "tidb_log_stream_table_pos"
 
-	// tidb log stream table pos
-	TiDBDemoStreamTablePos = "tidb_demo_stream_table_pos"
+	// tidb stream table demo pos
+	TiDBStreamTableDemoPos = "tidb_stream_table_demo_pos"
 )
 
 // Default TiDB system variable values.

--- a/sessionctx/variable/tidb_vars.go
+++ b/sessionctx/variable/tidb_vars.go
@@ -225,6 +225,9 @@ const (
 
 	// tidb log stream table pos
 	TiDBLogStreamTablePos = "tidb_log_stream_table_pos"
+
+	// tidb log stream table pos
+	TiDBDemoStreamTablePos = "tidb_demo_stream_table_pos"
 )
 
 // Default TiDB system variable values.

--- a/types/time.go
+++ b/types/time.go
@@ -186,6 +186,29 @@ type Time struct {
 	Fsp int
 }
 
+// Add user-defined time json unmarshal method
+func (t *Time) UnmarshalJSON(data []byte) (err error) {
+	tt, err := gotime.ParseInLocation(`"`+TimeFormat+`"`, string(data), gotime.Local)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	t.Time.year = uint16(tt.Year())
+	t.Time.month = uint8(tt.Month())
+	t.Time.day = uint8(tt.Day())
+	t.Time.hour = int(tt.Hour())
+	t.Time.minute = uint8(tt.Minute())
+	t.Time.second = uint8(tt.Second())
+	return nil
+}
+
+// Add user-defined time json marshal method
+func (t Time) MarshalJSON() ([]byte, error) {
+	d := fmt.Sprintf(`"%04d-%02d-%02d %02d:%02d:%02d"`, t.Time.Year(), t.Time.Month(), t.Time.Day(),
+		t.Time.Hour(), t.Time.Minute(), t.Time.Second())
+	return []byte(d), nil
+}
+
 // MaxMySQLTime returns Time with maximum mysql time type.
 func MaxMySQLTime(fsp int) Time {
 	return Time{Time: FromDate(0, 0, 0, TimeMaxHour, TimeMaxMinute, TimeMaxSecond, 0), Type: mysql.TypeDuration, Fsp: fsp}

--- a/util/mock/stream_data.go
+++ b/util/mock/stream_data.go
@@ -22,8 +22,13 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-// Mock data for stream reader.
-var MockStreamData []Event
+// Mock data for stream reader demo.
+var (
+	MockStreamData       []Event
+	MockKafkaStreamData  []KafkaEvent
+	MockPulsarStreamData []PulsarEvent
+	MockLogStreamData    []LogEvent
+)
 
 type Event struct {
 	ID         int64      `json:"id"`
@@ -31,18 +36,66 @@ type Event struct {
 	CreateTime types.Time `json:"create_time"`
 }
 
+type KafkaEvent struct {
+	ID         int64      `json:"id"`
+	Content    string     `json:"content"`
+	CreateTime types.Time `json:"create_time"`
+}
+
+type PulsarEvent struct {
+	ID         int64      `json:"id"`
+	Content    string     `json:"content"`
+	CreateTime types.Time `json:"create_time"`
+}
+
+type LogEvent struct {
+	ID         int64      `json:"id"`
+	Content    string     `json:"content"`
+	CreateTime types.Time `json:"create_time"`
+}
+
+func genData(i int, t types.Time) Event {
+	tt := types.Time{
+		Time: types.FromDate(t.Time.Year(), t.Time.Month(), t.Time.Day(), t.Time.Hour(), t.Time.Minute(), t.Time.Second()+i, t.Time.Microsecond()),
+		Type: mysql.TypeTimestamp,
+		Fsp:  types.DefaultFsp,
+	}
+	content := fmt.Sprintf("TiDB Stream Demo Data %d", i)
+	evt := Event{int64(i), content, tt}
+
+	return evt
+}
+
+func genKafkaData(i int, t types.Time) KafkaEvent {
+	tt := types.Time{
+		Time: types.FromDate(t.Time.Year(), t.Time.Month(), t.Time.Day(), t.Time.Hour(), t.Time.Minute(), t.Time.Second()+i, t.Time.Microsecond()),
+		Type: mysql.TypeTimestamp,
+		Fsp:  types.DefaultFsp,
+	}
+	content := fmt.Sprintf("TiDB Stream Demo Data %d", i)
+	evt := KafkaEvent{int64(i), content, tt}
+
+	return evt
+}
+
+func genPulsarData(i int, t types.Time) PulsarEvent {
+	evt := PulsarEvent{}
+	return evt
+}
+
+func genLogData(i int, t types.Time) LogEvent {
+	evt := LogEvent{}
+	return evt
+}
+
 func init() {
 	t := types.CurrentTime(mysql.TypeTimestamp)
 
-	for i := 0; i < 10000; i++ {
-		tt := types.Time{
-			Time: types.FromDate(t.Time.Year(), t.Time.Month(), t.Time.Day(), t.Time.Hour(), t.Time.Minute(), t.Time.Second()+i, t.Time.Microsecond()),
-			Type: mysql.TypeTimestamp,
-			Fsp:  types.DefaultFsp,
-		}
-		content := fmt.Sprintf("TiDB Stream Test Data %d", i)
-		evt := Event{int64(i), content, tt}
-		MockStreamData = append(MockStreamData, evt)
+	for i := 0; i < 100; i++ {
+		MockStreamData = append(MockStreamData, genData(i, t))
+		MockKafkaStreamData = append(MockKafkaStreamData, genKafkaData(i, t))
+		MockPulsarStreamData = append(MockPulsarStreamData, genPulsarData(i, t))
+		MockLogStreamData = append(MockLogStreamData, genLogData(i, t))
 	}
 
 	for i := 0; i < 10; i++ {
@@ -59,5 +112,9 @@ func init() {
 
 		MockStreamData[i] = evt
 		log.Errorf("[mock stream data]%v-%s", MockStreamData[i], string(data))
+
+		log.Errorf("[mock stream kafka data]%v", MockKafkaStreamData[i])
+		log.Errorf("[mock stream pulsar data]%v", MockPulsarStreamData[i])
+		log.Errorf("[mock stream log data]%v", MockLogStreamData[i])
 	}
 }

--- a/util/mock/stream_data.go
+++ b/util/mock/stream_data.go
@@ -14,10 +14,12 @@
 package mock
 
 import (
-	"strconv"
+	"encoding/json"
+	"fmt"
 
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/tidb/types"
+	log "github.com/sirupsen/logrus"
 )
 
 // Mock data for stream reader.
@@ -25,7 +27,7 @@ var MockStreamData []Event
 
 type Event struct {
 	ID         int64      `json:"id"`
-	Content    string     `json:"name"`
+	Content    string     `json:"content"`
 	CreateTime types.Time `json:"create_time"`
 }
 
@@ -38,7 +40,24 @@ func init() {
 			Type: mysql.TypeTimestamp,
 			Fsp:  types.DefaultFsp,
 		}
-		evt := Event{int64(i), strconv.Itoa(i), tt}
+		content := fmt.Sprintf("TiDB Stream Test Data %d", i)
+		evt := Event{int64(i), content, tt}
 		MockStreamData = append(MockStreamData, evt)
+	}
+
+	for i := 0; i < 10; i++ {
+		data, err := json.Marshal(MockStreamData[i])
+		if err != nil {
+			log.Fatalf("[mock stream data marshal failed]%v", err)
+		}
+
+		evt := Event{}
+		err = json.Unmarshal([]byte(data), &evt)
+		if err != nil {
+			log.Fatalf("[mock stream data unmarshal failed]%v", err)
+		}
+
+		MockStreamData[i] = evt
+		log.Errorf("[mock stream data]%v-%s", MockStreamData[i], string(data))
 	}
 }


### PR DESCRIPTION
Code changes

 - Add global variable for stream table pos
 e.g. `set @@global.tidb_kafka_stream_table_pos = 0;` works like kafka sql `SET 'auto.offset.reset' = 'earliest';`
 - Mock the dynamic stream table pos variable
 - Mock different kinds of stream source data